### PR TITLE
Refactor Table Processing Flow: Introduce process_tables() Batch Orchestrator and Move Table-Level Logging into process_table()

### DIFF
--- a/src/data_lakehouse_ingest/orchestrator/table_batch_processor.py
+++ b/src/data_lakehouse_ingest/orchestrator/table_batch_processor.py
@@ -1,0 +1,97 @@
+"""
+Batch table processing utilities for the Data Lakehouse Ingest framework.
+
+This module provides the `process_tables()` function, which coordinates the
+end-to-end processing of all tables defined in the ingestion context. It acts
+as a higher-level orchestrator above the per-table `process_table()` function,
+managing logging context, error capture, and aggregation of table-level
+reports.
+
+Responsibilities:
+    - Iterate through configured tables in the ingestion run.
+    - Apply dynamic logger context so logs include table identifiers.
+    - Delegate per-table work to `process_table()`.
+    - Capture and normalize any exceptions encountered during table processing.
+    - Produce two lists: successful/failed table reports and top-level errors.
+
+This module improves modularity by separating multi-table orchestration from
+the top-level `ingest()` function, resulting in cleaner orchestration flow.
+"""
+
+from typing import Any
+from .error_utils import error_entry_for_exception
+from .table_processor import process_table
+import logging
+from pyspark.sql import SparkSession
+from minio import Minio
+
+def process_tables(
+    spark: SparkSession,
+    logger: logging.Logger,
+    loader: Any,
+    ctx: dict,
+    started_at: str,
+    minio_client: Minio | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Process all tables defined in the ingestion context.
+
+    Iterates through the list of tables extracted from the ingestion context
+    (`ctx["tables"]`), applies per-table logging context, and delegates table-
+    level ingestion work to `process_table()`. All exceptions raised during
+    table processing are captured and converted into standardized error
+    entries using `error_entry_for_exception()`.
+
+    Args:
+        spark (SparkSession):
+            Active Spark session used for reading/writing data.
+        logger (logging.Logger):
+            Structured logger used for emitting JSON-formatted logs.
+        loader (Any):
+            The configuration loader containing resolved configuration and
+            schema information.
+        ctx (dict):
+            Ingestion context produced by `init_run_context()`. Must include
+            a `"tables"` key containing the list of table definitions.
+        started_at (str):
+            ISO-8601 timestamp marking when the ingestion run began.
+        minio_client (Minio | None, optional):
+            MinIO client used for reading data from S3-compatible sources.
+            Passed through to `process_table()`.
+
+    Returns:
+        tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+            A tuple containing:
+                - `table_reports`: List of per-table result dictionaries,
+                  each containing status, metrics, and/or error details.
+                - `error_list`: List of normalized error entries for all
+                  tables that encountered exceptions.
+
+    Notes:
+        - Each table is processed independently; a failure in one table does
+          not prevent others from being ingested.
+        - The returned lists are used by the top-level orchestrator to build
+          the final ingestion run report.
+    """
+    tables = ctx["tables"]
+    table_reports: list[dict[str, Any]] = []
+    error_list: list[dict[str, Any]] = []
+
+    for table in tables:
+        try:
+            report_row = process_table(
+                spark=spark,
+                logger=logger,
+                loader=loader,
+                ctx=ctx,
+                table=table,
+                run_started_at_iso=started_at,
+                minio_client=minio_client,
+            )
+            table_reports.append(report_row)
+        except Exception as e:
+            entry = error_entry_for_exception(table, e)
+            table_reports.append(entry)
+            error_list.append(entry)
+
+    return table_reports, error_list

--- a/src/data_lakehouse_ingest/orchestrator/table_processor.py
+++ b/src/data_lakehouse_ingest/orchestrator/table_processor.py
@@ -98,6 +98,14 @@ def process_table(
         >>> print(result["status"])
         success
     """
+    # --- Dynamic table context and logging ---
+    table_name = table.get("name", "pipeline_stage")
+
+    if hasattr(logger, "context_filter"):
+        logger.context_filter.set_table(table_name)
+
+    logger.info(f"Processing table: {table_name}")
+
     tenant = ctx["tenant"]
     namespace = ctx["namespace"]
     namespace_base_path = ctx["namespace_base_path"]
@@ -129,7 +137,6 @@ def process_table(
     opts = {k: (str(v).lower() if isinstance(v, bool) else v) for k, v in opts.items()}
     opts["recursiveFileLookup"] = "true"
 
-    logger.info(f"Processing table: {name}")
     logger.info(f"   Bronze: {bronze_path}")
     logger.info(f"   Silver: {silver_path}")
 

--- a/tests/orchestrator/test_table_batch_processor.py
+++ b/tests/orchestrator/test_table_batch_processor.py
@@ -1,0 +1,112 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from data_lakehouse_ingest.orchestrator.table_batch_processor import process_tables
+
+
+def test_process_tables_success():
+    """
+    Test that process_tables correctly iterates over tables,
+    delegates to process_table(), and aggregates reports.
+    """
+
+    # --- Mocks ---
+    spark = MagicMock()
+    logger = MagicMock()
+    loader = MagicMock()
+    minio_client = MagicMock()
+
+    ctx = {
+        "tables": [
+            {"name": "table1"},
+            {"name": "table2"}
+        ]
+    }
+
+    started_at = "2025-01-01T00:00:00Z"
+
+    # Mock process_table to return different rows for each call
+    mock_report_1 = {"status": "success", "table": "table1"}
+    mock_report_2 = {"status": "success", "table": "table2"}
+
+    with patch(
+        "data_lakehouse_ingest.orchestrator.table_batch_processor.process_table",
+        side_effect=[mock_report_1, mock_report_2]
+    ) as mock_process_table:
+
+        table_reports, error_list = process_tables(
+            spark=spark,
+            logger=logger,
+            loader=loader,
+            ctx=ctx,
+            started_at=started_at,
+            minio_client=minio_client,
+        )
+
+    # --- Assertions ---
+    assert table_reports == [mock_report_1, mock_report_2]
+    assert error_list == []
+
+    # Ensure process_table was called twice (once per table)
+    assert mock_process_table.call_count == 2
+
+    # Ensure logger context was set per table if logger.context_filter exists
+    if hasattr(logger, "context_filter"):
+        logger.context_filter.set_table.assert_any_call("table1")
+        logger.context_filter.set_table.assert_any_call("table2")
+
+    # Ensure logger was called with the table processing log
+    logger.info.assert_any_call("Processing table: table1")
+    logger.info.assert_any_call("Processing table: table2")
+
+
+def test_process_tables_with_exception():
+    """
+    Test that when process_table raises an exception, the error entry is created
+    and appended to both table_reports and error_list.
+    """
+
+    spark = MagicMock()
+    logger = MagicMock()
+    loader = MagicMock()
+    minio_client = MagicMock()
+
+    ctx = {"tables": [{"name": "boom_table"}]}
+    started_at = "2025-01-01T00:00:00Z"
+
+    # Mock process_table to raise an exception
+    with patch(
+        "data_lakehouse_ingest.orchestrator.table_batch_processor.process_table",
+        side_effect=Exception("Test error")
+    ):
+        with patch(
+            "data_lakehouse_ingest.orchestrator.table_batch_processor.error_entry_for_exception",
+            return_value={"status": "error", "table": "boom_table", "error": "Test error"}
+        ) as mock_error_entry:
+
+            table_reports, error_list = process_tables(
+                spark=spark,
+                logger=logger,
+                loader=loader,
+                ctx=ctx,
+                started_at=started_at,
+                minio_client=minio_client,
+            )
+
+    # --- Assertions ---
+    assert len(table_reports) == 1
+    assert len(error_list) == 1
+
+    assert table_reports[0] == {
+        "status": "error",
+        "table": "boom_table",
+        "error": "Test error"
+    }
+
+    assert error_list[0] == table_reports[0]
+
+    # Ensure error_entry_for_exception was used
+    mock_error_entry.assert_called_once()
+
+    # Verify that ProcessTable attempted to log
+    logger.info.assert_any_call("Processing table: boom_table")


### PR DESCRIPTION
his PR refactors the table ingestion workflow to improve modularity, clarity, and encapsulation within the Data Lakehouse Ingest framework. It introduces a new batch processing utility and relocates table-specific logging and context management to the appropriate module.

Key Changes
1. Added table_batch_processor.py

- A new orchestrator-level module containing the process_tables() function, responsible for:
- Iterating over tables defined in the ingestion context
- Delegating per-table work to process_table()
- Aggregating table-level results and error entries

Removing table-level responsibilities from core.ingest()

2. Updated table_processor.py

Per reviewer feedback:

- Moved dynamic table logging and context_filter setup into process_table()


3. Added unit test: test_table_batch_processor.py

- Validates correct delegation to process_table()

