### PR TITLE
Add error_utils module for standardized exception handling with unit tests

### DIFF
--- a/src/data_lakehouse_ingest/orchestrator/error_utils.py
+++ b/src/data_lakehouse_ingest/orchestrator/error_utils.py
@@ -1,0 +1,44 @@
+"""
+Error handling utilities for the Data Lakehouse Ingest framework.
+Provides helper functions to generate structured error entries
+for inclusion in ingestion reports and logs.
+
+This module standardizes how exceptions are represented during
+table-level processing, ensuring consistent error reporting across
+all stages of the ingestion pipeline.
+"""
+
+def error_entry_for_exception(table: dict, exc: Exception) -> dict[str, str]:
+    """
+    Create a standardized error entry dictionary for a failed table operation.
+
+    Converts an exception into a serializable error record suitable for
+    inclusion in the ingestion report or structured log output. Ensures
+    consistent representation of failure details across all ingestion steps.
+
+    Args:
+        table (dict): Table configuration dictionary from the ingestion config.
+            Expected to contain a "name" field identifying the table.
+        exc (Exception): The caught exception instance representing the failure.
+
+    Returns:
+        dict[str, str]: A dictionary containing:
+            - "name": Table name (or "<unknown>" if missing).
+            - "error": Exception message as a string.
+            - "status": Always set to "failed".
+
+    Example:
+        >>> try:
+        ...     raise ValueError("Missing required column")
+        ... except Exception as e:
+        ...     error_entry_for_exception({"name": "gene_table"}, e)
+        {'name': 'gene_table', 'error': 'Missing required column', 'status': 'failed'}
+
+    Notes:
+        - Keeps error serialization minimal and human-readable.
+        - Does not include stack traces; those are logged separately.
+        - Used in orchestration layers to populate both `error_list` and
+          table-level entries in the final ingestion report.
+    """
+    name = table.get("name", "<unknown>")
+    return {"name": name, "error": str(exc), "status": "failed"}

--- a/tests/orchestrator/test_error_utils.py
+++ b/tests/orchestrator/test_error_utils.py
@@ -1,0 +1,7 @@
+from data_lakehouse_ingest.orchestrator.error_utils import error_entry_for_exception
+
+def test_error_entry_for_exception_returns_expected_dict():
+    exc = ValueError("bad data")
+    table = {"name": "test_table"}
+    entry = error_entry_for_exception(table, exc)
+    assert entry == {"name": "test_table", "error": "bad data", "status": "failed"}


### PR DESCRIPTION
This PR introduces a dedicated `error_utils` module to standardize how exceptions are captured and represented throughout the Data Lakehouse Ingest framework. It includes a helper function, `error_entry_for_exception()`, which converts exceptions into consistent, serializable error records for use in ingestion reports and structured logs.