### PR TITLE
Support structured schema column comments in ConfigLoader and expand unit test coverage

### DIFF
--- a/src/data_lakehouse_ingest/config_loader.py
+++ b/src/data_lakehouse_ingest/config_loader.py
@@ -169,10 +169,16 @@ class ConfigLoader:
         Ensures:
           - Required top-level keys exist (dataset, tables)
           - 'paths' is optional; if present, it must include 'bronze_base'
-          - Each table defines 'name'
-          - Table schema may be provided via 'schema_sql' (string) or
-            'schema' (list of column definitions); if neither is provided,
-            schema inference is allowed
+          - Each table defines a valid non-empty 'name'
+          - Table schema may be provided via:
+              - 'schema_sql' (string), or
+              - 'schema' (list of structured column definitions)
+          - If neither schema form is provided, schema inference is allowed
+          - For structured schema entries:
+              - each entry must be an object/map
+              - 'column' (or 'name') and 'type' are required
+              - 'nullable', if provided, must be boolean
+              - 'comment', if provided, must be either a string or a dict
 
         Raises:
             ValueError: If required keys are missing or invalid.
@@ -273,10 +279,10 @@ class ConfigLoader:
                             f"Table '{table_name}' schema entry for column "
                             f"'{col_name}' has non-boolean 'nullable'."
                         )
-                    if "comment" in coldef and not isinstance(coldef["comment"], str):
+                    if "comment" in coldef and not isinstance(coldef["comment"], (str, dict)):
                         validation_errors.append(
                             f"Table '{table_name}' schema entry for column "
-                            f"'{col_name}' has non-string 'comment'."
+                            f"'{col_name}' has invalid 'comment' (must be a string or dict)."
                         )
 
         # ---- Optional warnings ----

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -94,6 +94,52 @@ def test_load_from_s3_requires_minio_client(caplog):
     assert "MinIO client must be provided for s3a:// paths." in caplog.text
 
 
+def test_load_from_s3_invalid_path_format():
+    """Rejects malformed s3a:// config paths that do not include bucket/key."""
+    mock_minio = MagicMock()
+
+    with pytest.raises(ValueError, match=r"Invalid s3a:// path format"):
+        ConfigLoader("s3a://bucket-only", minio_client=mock_minio)
+
+
+# ---------------------------------------------------------------------
+# Local file success & failure paths
+# ---------------------------------------------------------------------
+
+
+def test_load_from_local_file_not_found():
+    """Raises FileNotFoundError for missing config files inside the safe directory."""
+    safe_file = Path.home() / ".data_lakehouse" / "configs" / "does_not_exist.json"
+
+    with pytest.raises(FileNotFoundError):
+        ConfigLoader(str(safe_file))
+
+
+def test_load_from_local_file_invalid_json(caplog):
+    """Raises JSONDecodeError when a local config file contains invalid JSON."""
+    safe_file = Path.home() / ".data_lakehouse" / "configs" / "bad_config.json"
+    safe_file.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        safe_file.write_text("{ bad json }", encoding="utf-8")
+
+        with caplog.at_level(logging.ERROR), pytest.raises(json.JSONDecodeError):
+            ConfigLoader(str(safe_file))
+
+        assert f"Invalid JSON in config file {safe_file}" in caplog.text
+    finally:
+        if safe_file.exists():
+            safe_file.unlink()
+
+
+def test_load_from_local_file_rejects_unsafe_path():
+    """Rejects config paths outside the safe config directory."""
+    unsafe_path = Path.cwd() / "outside_config.json"
+
+    with pytest.raises(ValueError, match=r"Unsafe or out-of-sandbox config path detected"):
+        ConfigLoader(str(unsafe_path))
+
+
 # ---------------------------------------------------------------------
 # MinIO read success & failure paths
 # ---------------------------------------------------------------------
@@ -134,6 +180,17 @@ def test_load_from_s3_failure_s3error(caplog):
         ConfigLoader("s3a://test-bucket/config.json", minio_client=mock_minio)
 
     assert "Failed to read s3a://test-bucket/config.json from MinIO" in caplog.text
+
+
+def test_load_from_s3_unexpected_exception(caplog):
+    """Raises when an unexpected exception occurs while reading config from MinIO."""
+    mock_minio = MagicMock()
+    mock_minio.get_object.side_effect = Exception("boom")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(Exception, match="boom"):
+        ConfigLoader("s3a://test-bucket/config.json", minio_client=mock_minio)
+
+    assert "Unexpected error while reading s3a://test-bucket/config.json from MinIO" in caplog.text
 
 
 # ---------------------------------------------------------------------
@@ -301,7 +358,7 @@ def test_structured_schema_entry_missing_column_or_name_raises(minimal_config):
 
 
 def test_structured_schema_nullable_and_comment_type_validation(minimal_config):
-    """Rejects structured schemas where 'nullable' is non-boolean and/or 'comment' is non-string."""
+    """Rejects structured schemas where 'nullable' is non-boolean and/or 'comment' is neither a string nor a dict."""
     cfg = minimal_config.copy()
     cfg["tables"] = [
         {
@@ -318,7 +375,32 @@ def test_structured_schema_nullable_and_comment_type_validation(minimal_config):
 
     msg = str(excinfo.value)
     assert "has non-boolean 'nullable'." in msg
-    assert "has non-string 'comment'." in msg
+    assert "must be a string or dict" in msg
+
+
+def test_structured_schema_accepts_dict_comment(minimal_config):
+    """Accepts structured schema comments when provided as dictionaries."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        {
+            "name": "browser_cazy_family",
+            "schema": [
+                {
+                    "column": "id",
+                    "type": "STRING",
+                    "nullable": True,
+                    "comment": {"description": "primary id"},
+                }
+            ],
+            "bronze_path": "s3a://bucket/bronze/browser_cazy_family.csv",
+        }
+    ]
+
+    loader = ConfigLoader(cfg)
+    schema = loader.get_table_schema("browser_cazy_family")
+
+    assert schema is not None
+    assert schema[0]["comment"] == {"description": "primary id"}
 
 
 def test_paths_present_missing_bronze_base_raises(minimal_config):
@@ -498,3 +580,74 @@ def test_get_bronze_path_requires_string_bronze_path(minimal_config, bad_bronze_
         match=r"'bronze_path' must be defined as a string for table 'browser_cazy_family'\.",
     ):
         loader.get_bronze_path("browser_cazy_family")
+
+
+def test_get_csv_defaults_returns_configured_values(minimal_config):
+    """Returns configured CSV defaults from the config."""
+    loader = ConfigLoader(minimal_config)
+
+    defaults = loader.get_csv_defaults()
+
+    assert defaults["header"] is True
+    assert defaults["delimiter"] == ","
+    assert defaults["inferSchema"] is False
+
+
+def test_get_tables_skips_disabled_tables_and_logs(minimal_config, caplog):
+    """Skips disabled tables and logs how many were excluded."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        cfg["tables"][0],
+        {
+            "name": "disabled_table",
+            "enabled": False,
+            "schema_sql": "id STRING",
+            "bronze_path": "s3a://bucket/bronze/disabled.csv",
+        },
+    ]
+
+    with caplog.at_level(logging.INFO):
+        loader = ConfigLoader(cfg)
+        tables = loader.get_tables()
+
+    assert len(tables) == 1
+    assert tables[0]["name"] == "browser_cazy_family"
+    assert "1 table(s) are disabled and will be skipped." in caplog.text
+
+
+def test_is_table_enabled_returns_expected_values(minimal_config):
+    """Returns correct enabled status for present and missing tables."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        {
+            "name": "enabled_table",
+            "enabled": True,
+            "schema_sql": "id STRING",
+            "bronze_path": "file1.csv",
+        },
+        {
+            "name": "disabled_table",
+            "enabled": False,
+            "schema_sql": "id STRING",
+            "bronze_path": "file2.csv",
+        },
+    ]
+
+    loader = ConfigLoader(cfg)
+
+    assert loader.is_table_enabled("enabled_table") is True
+    assert loader.is_table_enabled("disabled_table") is False
+    assert loader.is_table_enabled("missing_table") is False
+
+
+def test_get_defaults_for_returns_direct_format_defaults(minimal_config):
+    """Returns format defaults directly when explicitly defined in config."""
+    cfg = minimal_config.copy()
+    cfg["defaults"] = {
+        "json": {"multiline": True},
+        "csv": {"header": True, "delimiter": ",", "inferSchema": False},
+    }
+
+    loader = ConfigLoader(cfg)
+
+    assert loader.get_defaults_for("json") == {"multiline": True}


### PR DESCRIPTION
This PR updates `ConfigLoader` and its unit tests to support structured JSON-style column comments in schema definitions.

Previously, column `comment` metadata was documented and validated primarily as string-based metadata. This change aligns the loader and tests with the newer behavior that allows `comment` to also be provided as a dictionary/object for richer structured metadata.

**Key Changes**
- Updated `ConfigLoader` validation logic/documentation to reflect support for dict-based column comments in structured schemas
- Clarified docstrings around structured schema validation behavior
- Expanded unit tests to cover:
  - valid dict-based `comment` values
  - invalid `comment` types
  - structured schema validation behavior related to comments
  - previously uncovered branches in `config_loader.py`