### PR TITLE
Add support for JSON-style column comments in schema_utils with test coverage

### DIFF
--- a/src/data_lakehouse_ingest/orchestrator/schema_utils.py
+++ b/src/data_lakehouse_ingest/orchestrator/schema_utils.py
@@ -1,9 +1,10 @@
 """
 Schema utilities for the Data Lakehouse Ingest framework.
 
-Provides helpers to resolve table schemas, parse SQL-style schema definitions,
-and align DataFrame columns using governed Spark DataTypes, including support
-for DECIMAL(p,s), ARRAY<T>, and MAP<K,V> types.
+Provides helpers to resolve table schemas, parse SQL-style and structured
+schema definitions, preserve structured column metadata (including string
+and JSON-style column comments), and align DataFrame columns using governed
+Spark DataTypes, including support for DECIMAL(p,s), ARRAY<T>, and MAP<K,V> types.
 """
 
 from minio import Minio
@@ -182,7 +183,8 @@ class SchemaSource(Enum):
 
         - Metadata availability:
             Column-level metadata (e.g., comments) may be present when the schema
-            is defined using a structured list-of-maps. Metadata application is
+            is defined using a structured list-of-maps. Comments may be
+            plain strings or structured JSON-style dictionaries. Metadata application is
             driven by the presence of such metadata in the resolved schema, not
             by the schema source enum itself.
 
@@ -252,6 +254,9 @@ def resolve_schema(
            - If `schema` is provided as a **non-empty** list-of-maps, it is parsed
              via `parse_schema_structured()` and returned as normalized
              `(name, DataType)` tuples with `SchemaSource.SCHEMA_STRUCTURED`.
+           - Structured schema entries may include optional metadata such as
+             `nullable` and `comment`. Comment values may be strings or JSON-style
+             dictionaries and are preserved separately in `comment_metadata`.
 
         3) SQL-style schema (`schema_sql`):
            - If `schema` is absent/empty and `schema_sql` is a non-empty string, it is
@@ -281,6 +286,11 @@ def resolve_schema(
         table (dict[str, object]):
             Table definition from the ingestion config. Only schema-related keys are used
             here: `schema`, `schema_sql`, and `linkml_schema`.
+
+            For structured schemas, column definitions may also include metadata such as
+            `nullable` and `comment`. Comment values may be plain strings or structured
+            JSON-style dictionaries and are preserved in `comment_metadata` for downstream
+    Delta column comment application.
         logger (logging.Logger):
             Logger for reporting schema resolution decisions.
         minio_client (Minio | None):
@@ -753,7 +763,7 @@ def parse_schema_structured(
         # Optional: comment
         if "comment" in coldef:
             comment_val = coldef["comment"]
-            if comment_val is not None and not isinstance(comment_val, str):
+            if comment_val is not None and not isinstance(comment_val, (str, dict)):
                 raise ValueError(
                     f"Schema entry for '{col_name}' has invalid 'comment' "
                     f"(expected string, got {type(comment_val).__name__})"

--- a/tests/orchestrator/test_schema_utils.py
+++ b/tests/orchestrator/test_schema_utils.py
@@ -472,19 +472,21 @@ def test_parse_schema_structured_raises_on_nullable_not_bool():
         parse_schema_structured(schema, logger)
 
 
-def test_parse_schema_structured_raises_on_comment_not_string_or_none():
-    logger = MagicMock()
-    schema = [{"column": "id", "type": "INT", "comment": 123}]  # invalid
-
-    with pytest.raises(ValueError, match=r"invalid 'comment'"):
-        parse_schema_structured(schema, logger)
-
-
 def test_parse_schema_structured_raises_when_column_not_string():
+    """Raises ValueError when a structured schema column name is not a string."""
     logger = MagicMock()
     schema = [{"column": 123, "type": "INT"}]
 
     with pytest.raises(ValueError, match=r"invalid 'column'.*expected string"):
+        parse_schema_structured(schema, logger)
+
+
+def test_parse_schema_structured_raises_on_comment_invalid_type():
+    """Raises ValueError when a structured schema comment has an unsupported type."""
+    logger = MagicMock()
+    schema = [{"column": "id", "type": "INT", "comment": 123}]
+
+    with pytest.raises(ValueError, match=r"invalid 'comment'"):
         parse_schema_structured(schema, logger)
 
 
@@ -494,6 +496,17 @@ def test_parse_schema_structured_raises_when_type_not_string():
 
     with pytest.raises(ValueError, match=r"invalid 'type'.*expected string"):
         parse_schema_structured(schema, logger)
+
+
+def test_parse_schema_structured_allows_comment_dict():
+    """Parses a structured schema entry when comment is provided as a dict."""
+    logger = MagicMock()
+    schema = [{"column": "id", "type": "INT", "comment": {"description": "pk"}}]
+
+    parsed = parse_schema_structured(schema, logger)
+
+    assert parsed[0][0] == "id"
+    assert isinstance(parsed[0][1], IntegerType)
 
 
 # ----------------------------------------------------------------------
@@ -617,6 +630,27 @@ def test_resolve_schema_returns_structured_schema_with_map_comment_metadata():
     assert resolved.schema_defs is not None
     assert resolved.schema_defs[0][0] == "attrs"
     assert isinstance(resolved.schema_defs[0][1], MapType)
+
+
+def test_resolve_schema_preserves_dict_comment_metadata():
+    """Resolves structured schema and preserves dict-based column comment metadata."""
+    table = {
+        "name": "t1",
+        "schema": [
+            {"column": "id", "type": "INT", "comment": {"description": "pk"}},
+        ],
+    }
+
+    mock_spark = MagicMock()
+    mock_logger = MagicMock()
+
+    resolved = resolve_schema(mock_spark, table, mock_logger)
+
+    assert resolved.schema_source == SchemaSource.SCHEMA_STRUCTURED
+    assert resolved.comment_metadata == [{"column": "id", "comment": {"description": "pk"}}]
+    assert resolved.schema_defs is not None
+    assert resolved.schema_defs[0][0] == "id"
+    assert isinstance(resolved.schema_defs[0][1], IntegerType)
 
 
 def test_apply_schema_columns_converts_json_string_to_map():


### PR DESCRIPTION
Updates `parse_schema_structured()` to allow structured schema column comments to be provided as JSON-style dictionaries in addition to strings.

**Key Changes**
- Updated comment validation in `schema_utils.py` to accept `dict` values for the `comment` field
- Added/updated unit tests in `test_schema_utils.py` to cover:
  - valid dict-based comments
  - invalid comment type handling
  - preservation of structured comment metadata where applicable