### PR TITLE
Add JSON-style (dict) column comment support in delta_comments

### DIFF
--- a/src/data_lakehouse_ingest/utils/delta_comments.py
+++ b/src/data_lakehouse_ingest/utils/delta_comments.py
@@ -3,12 +3,14 @@ Delta table column comment utilities.
 
 Provides helpers to apply column-level comments to existing Spark/Delta
 tables using a structured list-of-maps schema definition. The module
-uses Spark SQL to update column metadata, safely escapes comment strings,
-skips missing or empty comments gracefully, and returns a structured
-report suitable for logging, auditing, and ingestion metadata.
+supports both plain string comments and JSON-style dict comments,
+safely escapes comment strings, skips missing or empty comments gracefully,
+and returns a structured report suitable for logging, auditing, and
+ingestion metadata.
 """
 
 import logging
+import json
 from typing import Any
 
 from pyspark.sql import SparkSession
@@ -100,9 +102,15 @@ def apply_comments_from_table_schema(
 
     Only schema entries that define both:
       - a column name (`column` or `name`)
-      - a non-empty string `comment`
+      - a non-empty `comment`
 
     will be applied. All other entries are skipped safely.
+
+    Supported comment formats:
+      - Plain string comments
+      - JSON-style dict comments, which are serialized to JSON before being stored
+
+     Unicode characters in comments are preserved.
 
     Args:
         spark: Active SparkSession.
@@ -116,6 +124,17 @@ def apply_comments_from_table_schema(
                   "nullable": false,
                   "comment": "Unique gene identifier"
                 }
+
+            Dict-based comments are also supported, for example:
+                {
+                  "column": "species",
+                  "type": "string",
+                  "comment": {
+                      "description": "Scientific name",
+                      "source": "/api/v1/species"
+                  }
+                }
+
         logger: Optional logger for structured logging.
         require_existing_table: If True, verifies that the table exists
             before attempting to apply comments.
@@ -148,6 +167,9 @@ def apply_comments_from_table_schema(
     for coldef in table_schema:
         col = coldef.get("column") or coldef.get("name")
         comment = coldef.get("comment")
+
+        if isinstance(comment, dict):
+            comment = json.dumps(comment, ensure_ascii=False)
 
         if not col:
             skipped += 1

--- a/tests/utils/test_delta_comments.py
+++ b/tests/utils/test_delta_comments.py
@@ -138,3 +138,72 @@ def test_apply_comments_marks_failed_when_alter_comment_fails_for_a_column():
     assert report["failed"] == 1
     assert report["details"][0]["status"] == "failed"
     assert report["details"][0]["column"] == "gene_id"
+
+
+def test_apply_comments_serializes_dict_comment_and_applies_it():
+    """Serializes dict comments to JSON and applies them as escaped SQL column comments."""
+    spark = FakeSpark()
+    schema = [
+        {
+            "column": "gene_id",
+            "comment": {
+                "description": "Gene identifier",
+                "source": "/api/v1",
+                "flags": {"demo": True},
+            },
+        }
+    ]
+
+    report = apply_comments_from_table_schema(
+        spark, "db.tbl", schema, logger=logging.getLogger("test")
+    )
+
+    assert report["status"] == "success"
+    assert report["applied"] == 1
+    assert report["skipped"] == 0
+    assert report["failed"] == 0
+
+    sql_text = spark.sql_calls[0]
+    assert 'ALTER TABLE db.tbl ALTER COLUMN `gene_id` COMMENT "' in sql_text
+    assert '\\"description\\": \\"Gene identifier\\"' in sql_text
+    assert '\\"source\\": \\"/api/v1\\"' in sql_text
+    assert '\\"flags\\": {\\"demo\\": true}' in sql_text
+
+
+def test_apply_comments_preserves_unicode_in_dict_comment():
+    """Preserves Unicode characters when serializing dict comments to JSON."""
+    spark = FakeSpark()
+    schema = [
+        {
+            "column": "species",
+            "comment": {"description": "Café naïve β-cell 漢字"},
+        }
+    ]
+
+    report = apply_comments_from_table_schema(
+        spark, "db.tbl", schema, logger=logging.getLogger("test")
+    )
+
+    assert report["status"] == "success"
+    sql_text = spark.sql_calls[0]
+    assert "Café naïve β-cell 漢字" in sql_text
+    assert "\\u" not in sql_text
+
+
+def test_apply_comments_skips_non_string_non_dict_comment():
+    """Skips comments that are neither strings nor dicts."""
+    spark = FakeSpark()
+    schema = [
+        {"column": "gene_id", "comment": 123},
+    ]
+
+    report = apply_comments_from_table_schema(
+        spark, "db.tbl", schema, logger=logging.getLogger("test")
+    )
+
+    assert report["status"] == "success"
+    assert report["applied"] == 0
+    assert report["skipped"] == 1
+    assert report["failed"] == 0
+    assert report["details"][0]["status"] == "skipped"
+    assert report["details"][0]["reason"] == "no comment"


### PR DESCRIPTION
This PR adds support for JSON-style (dict-based) column comments in `delta_comments`, enabling richer and more structured metadata to be applied to Delta table columns.

**Key Changes**

- Support for dict-based comments by serializing them to JSON before applying via Spark SQL
- Preserve Unicode characters using` json.dumps(..., ensure_ascii=False)`
- Maintain safe SQL escaping for comment strings
- Added/updated unit tests to cover:
  - Dict-based comment serialization and application
  - Unicode preservation in comments
  - Skipping invalid (non-string, non-dict) comment types