### PR TITLE
Add table-level comment support in ConfigLoader with validation and test coverage

### DIFF
--- a/src/data_lakehouse_ingest/config_loader.py
+++ b/src/data_lakehouse_ingest/config_loader.py
@@ -38,6 +38,12 @@ class ConfigLoader:
       - Inline JSON strings
       - MinIO object storage (via s3a:// paths)
 
+    Notes:
+        - Local file loading is restricted to a safe configuration directory.
+        - Validation supports both SQL-style and structured schema definitions.
+        - Table-level and column-level comments may be provided as plain strings
+          or JSON-style dictionaries.
+
     Attributes:
         config (dict[str, Any]): The parsed configuration dictionary.
         logger (logging.Logger): The logger instance for structured logging.

--- a/src/data_lakehouse_ingest/config_loader.py
+++ b/src/data_lakehouse_ingest/config_loader.py
@@ -2,7 +2,7 @@
 Purpose:
     Provides a configuration loader for the Data Lakehouse Ingest framework.
     Supports reading configuration from:
-      - Local JSON file
+      - Local JSON file (with path traversal protection)
       - Inline JSON string
       - MinIO object storage (s3a://bucket/key)
 

--- a/src/data_lakehouse_ingest/config_loader.py
+++ b/src/data_lakehouse_ingest/config_loader.py
@@ -9,6 +9,9 @@ Purpose:
     Performs validation of minimal required fields, applies defensive checks
     (e.g., path traversal prevention), and exposes convenient accessors for
     tenant, dataset, paths, and per-table definitions.
+
+    Also supports structured metadata such as table-level and column-level comments
+    for enhanced data context and discoverability.
 """
 
 from __future__ import annotations
@@ -174,11 +177,13 @@ class ConfigLoader:
               - 'schema_sql' (string), or
               - 'schema' (list of structured column definitions)
           - If neither schema form is provided, schema inference is allowed
+          - Table-level 'comment', if provided, must be either a string or a dict
           - For structured schema entries:
               - each entry must be an object/map
               - 'column' (or 'name') and 'type' are required
               - 'nullable', if provided, must be boolean
-              - 'comment', if provided, must be either a string or a dict
+              - For structured schema entries:
+                  - 'comment', if provided, must be either a string or a dict
 
         Raises:
             ValueError: If required keys are missing or invalid.
@@ -226,6 +231,17 @@ class ConfigLoader:
                 continue
 
             table_name = t["name"]
+
+            # Validate optional table-level comment (must be str or dict if provided)
+            table_comment = t.get("comment")
+            if (
+                "comment" in t
+                and table_comment is not None
+                and not isinstance(table_comment, (str, dict))
+            ):
+                validation_errors.append(
+                    f"Table '{table_name}' has invalid 'comment' (must be a string or dict)."
+                )
 
             schema_sql = t.get("schema_sql")
             schema_list = t.get("schema")
@@ -350,6 +366,31 @@ class ConfigLoader:
         if table is None:
             return False
         return bool(table.get("enabled", True))
+
+    def get_table_comment(self, table_name: str) -> str | dict[str, Any] | None:
+        """
+        Retrieve the table-level comment for a given table.
+
+        The comment may be:
+        - a plain string, or
+        - a structured JSON-style dictionary (for richer metadata)
+
+        Args:
+            table_name (str): Name of the table.
+
+        Returns:
+            str | dict[str, Any] | None:
+                The table comment if defined, otherwise None.
+
+        Notes:
+            - If the table is not found, None is returned.
+            - Only string and dict types are considered valid comment formats.
+        """
+        t = self.get_table(table_name)
+        if not t:
+            return None
+        comment = t.get("comment")
+        return comment if isinstance(comment, (str, dict)) or comment is None else None
 
     def get_bronze_path(self, table_name: str) -> str:
         """

--- a/src/data_lakehouse_ingest/config_loader.py
+++ b/src/data_lakehouse_ingest/config_loader.py
@@ -188,8 +188,7 @@ class ConfigLoader:
               - each entry must be an object/map
               - 'column' (or 'name') and 'type' are required
               - 'nullable', if provided, must be boolean
-              - For structured schema entries:
-                  - 'comment', if provided, must be either a string or a dict
+              - 'comment', if provided, must be either a string or a dict
 
         Raises:
             ValueError: If required keys are missing or invalid.
@@ -240,11 +239,7 @@ class ConfigLoader:
 
             # Validate optional table-level comment (must be str or dict if provided)
             table_comment = t.get("comment")
-            if (
-                "comment" in t
-                and table_comment is not None
-                and not isinstance(table_comment, (str, dict))
-            ):
+            if "comment" in t and not isinstance(table_comment, (str, dict)):
                 validation_errors.append(
                     f"Table '{table_name}' has invalid 'comment' (must be a string or dict)."
                 )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -418,6 +418,65 @@ def test_paths_present_missing_bronze_base_raises(minimal_config):
         ConfigLoader(cfg)
 
 
+def test_table_level_comment_accepts_string(minimal_config):
+    """Accepts a plain string table-level comment and returns it via the accessor."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        {
+            "name": "browser_cazy_family",
+            "schema_sql": "id STRING",
+            "bronze_path": "s3a://bucket/bronze/browser_cazy_family.csv",
+            "comment": "CAZy family reference table",
+        }
+    ]
+
+    loader = ConfigLoader(cfg)
+
+    assert loader.get_table_comment("browser_cazy_family") == "CAZy family reference table"
+
+
+def test_table_level_comment_accepts_dict(minimal_config):
+    """Accepts a JSON-style dict table-level comment and returns it unchanged."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        {
+            "name": "browser_cazy_family",
+            "schema_sql": "id STRING",
+            "bronze_path": "s3a://bucket/bronze/browser_cazy_family.csv",
+            "comment": {
+                "description": "CAZy family reference table",
+                "owner": "arkinlab",
+            },
+        }
+    ]
+
+    loader = ConfigLoader(cfg)
+
+    assert loader.get_table_comment("browser_cazy_family") == {
+        "description": "CAZy family reference table",
+        "owner": "arkinlab",
+    }
+
+
+def test_table_level_comment_invalid_type_raises(minimal_config):
+    """Rejects table-level comments that are neither a string nor a dict."""
+    cfg = minimal_config.copy()
+    cfg["tables"] = [
+        {
+            "name": "browser_cazy_family",
+            "schema_sql": "id STRING",
+            "bronze_path": "s3a://bucket/bronze/browser_cazy_family.csv",
+            "comment": 123,
+        }
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"Table 'browser_cazy_family' has invalid 'comment' \(must be a string or dict\)\.",
+    ):
+        ConfigLoader(cfg)
+
+
 # ---------------------------------------------------------------------
 # Accessor tests
 # ---------------------------------------------------------------------
@@ -651,3 +710,14 @@ def test_get_defaults_for_returns_direct_format_defaults(minimal_config):
     loader = ConfigLoader(cfg)
 
     assert loader.get_defaults_for("json") == {"multiline": True}
+
+
+def test_get_table_comment_returns_none_for_missing_table(minimal_config, caplog):
+    """Returns None when requesting a table-level comment for a missing table."""
+    loader = ConfigLoader(minimal_config)
+
+    with caplog.at_level(logging.WARNING):
+        comment = loader.get_table_comment("does_not_exist")
+
+    assert comment is None
+    assert "Requested table 'does_not_exist' not found in configuration." in caplog.text


### PR DESCRIPTION
This PR introduces support for table-level comments in the `ConfigLoader`, extending the existing column-level comment functionality.

**Key Changes**

- Added support for defining table-level comments in config JSON
- Supports both:
  - Plain string comments
  - JSON-style (`dict`) comments
- Implemented validation logic for table-level comments
- Added accessor method(s) in `ConfigLoader` to retrieve table-level comments
- Updated unit tests in `test_config_loader.py` to cover:
  - Valid table-level comment parsing
  - JSON-style comment handling
  - Validation behavior for invalid inputs