### PR TITLE
Add support for table-level comments in table_processor with test coverage

### DIFF
--- a/src/data_lakehouse_ingest/orchestrator/table_processor.py
+++ b/src/data_lakehouse_ingest/orchestrator/table_processor.py
@@ -62,11 +62,11 @@ def process_table(
     - Loads data either from the Bronze path via Spark or from a provided DataFrame override
     - Applies schema alignment and column cleanup
     - Writes the processed DataFrame to the Silver Delta location
-    - Applies Delta table comments when table-level comment metadata is provided
+    - Applies Delta table comments when the table config includes a non-null `comment` value
     - Applies Delta column comments when a structured (list-of-maps) schema is used
     - Returns a structured result object summarizing ingestion results
 
-    Table comments are applied when the table config includes a `comment` value.
+    Table comments are applied only when the table config includes a non-null `comment` value.
     Column comments are applied when a structured schema with comments metadata is available.
 
     Args:
@@ -249,14 +249,15 @@ def process_table(
 
     full_table_name = f"{namespace}.{name}"
 
-    table_comment_report = apply_table_comment(
-        spark=spark,
-        full_table_name=full_table_name,
-        table_comment=table.get("comment"),
-        logger=logger,
-        require_existing_table=True,
-    )
-    logger.info(f"Table comment apply report: {table_comment_report}")
+    if "comment" in table and table.get("comment") is not None:
+        table_comment_report = apply_table_comment(
+            spark=spark,
+            full_table_name=full_table_name,
+            table_comment=table.get("comment"),
+            logger=logger,
+            require_existing_table=True,
+        )
+        logger.info(f"Table comment apply report: {table_comment_report}")
 
     # Applies Delta column comments when comment metadata is available (from structured schema)
     column_comments_report = None

--- a/src/data_lakehouse_ingest/orchestrator/table_processor.py
+++ b/src/data_lakehouse_ingest/orchestrator/table_processor.py
@@ -8,6 +8,7 @@ Purpose:
       - Data loading either from the Bronze layer (via Spark) or from a provided DataFrame
       - Schema application and column alignment
       - Writing curated data to the Silver layer in Delta format
+      - Applying table-level and column-level Delta comments when configured
 """
 
 from __future__ import annotations
@@ -27,7 +28,10 @@ from data_lakehouse_ingest.orchestrator.io_utils import (
     load_table_data,
     write_to_delta,
 )
-from data_lakehouse_ingest.utils.delta_comments import apply_comments_from_table_schema
+from data_lakehouse_ingest.utils.delta_comments import (
+    apply_comments_from_table_schema,
+    apply_table_comment,
+)
 
 from .models import (
     TableProcessSuccess,
@@ -58,9 +62,11 @@ def process_table(
     - Loads data either from the Bronze path via Spark or from a provided DataFrame override
     - Applies schema alignment and column cleanup
     - Writes the processed DataFrame to the Silver Delta location
+    - Applies Delta table comments when table-level comment metadata is provided
     - Applies Delta column comments when a structured (list-of-maps) schema is used
     - Returns a structured result object summarizing ingestion results
 
+    Table comments are applied when the table config includes a `comment` value.
     Column comments are applied when a structured schema with comments metadata is available.
 
     Args:
@@ -85,6 +91,7 @@ def process_table(
                 - "format": Input format override (optional)
                 - "mode": Write mode (e.g., "overwrite", "append")
                 - "partition_by": Optional partition columns
+                - "comment": Optional table-level comment as a string or dict
 
         run_started_at_iso (str):
             ISO-8601 timestamp representing when the pipeline run began.
@@ -107,7 +114,8 @@ def process_table(
                 - name, tenant, target_table
                 - bronze_path, silver_path
                 - rows_in, rows_written, elapsed_sec
-                - comments_report
+                - table_comment_report
+                - column_comments_report
                 - status (represented by ProcessStatus)
 
             The failure result includes fields such as:
@@ -237,19 +245,31 @@ def process_table(
         logger=logger,
     )
 
+    table_comment_report = None
+
+    full_table_name = f"{namespace}.{name}"
+
+    table_comment_report = apply_table_comment(
+        spark=spark,
+        full_table_name=full_table_name,
+        table_comment=table.get("comment"),
+        logger=logger,
+        require_existing_table=True,
+    )
+    logger.info(f"Table comment apply report: {table_comment_report}")
+
     # Applies Delta column comments when comment metadata is available (from structured schema)
-    comments_report = None
+    column_comments_report = None
 
     if resolved.comment_metadata:
-        full_table_name = f"{namespace}.{name}"
-        comments_report = apply_comments_from_table_schema(
+        column_comments_report = apply_comments_from_table_schema(
             spark=spark,
             full_table_name=full_table_name,
             table_schema=resolved.comment_metadata,
             logger=logger,
             require_existing_table=True,
         )
-        logger.info(f"Column comment apply report: {comments_report}")
+        logger.info(f"Column comment apply report: {column_comments_report}")
 
     rows_rejected = 0
     partitions_written = None
@@ -276,5 +296,6 @@ def process_table(
         quarantine_path=quarantine_path,
         elapsed_sec=elapsed_sec,
         status=ProcessStatus.SUCCESS,
-        comments_report=comments_report,
+        table_comment_report=table_comment_report,
+        column_comments_report=column_comments_report,
     )

--- a/tests/orchestrator/test_table_processor.py
+++ b/tests/orchestrator/test_table_processor.py
@@ -40,6 +40,11 @@ def table_config():
 # Regular ingestion path
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
     autospec=True,
     return_value=SimpleNamespace(
@@ -75,6 +80,7 @@ def test_process_table_success(
     mock_load_data,
     mock_detect_format,
     mock_resolve_schema,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -118,7 +124,8 @@ def test_process_table_success(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": None,
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": None,
     }
 
     mock_detect_format.assert_called_once_with("s3a://bronze/test_table/", "csv")
@@ -156,6 +163,11 @@ def test_process_table_success(
 # ---------------------------------------------------------------------
 # Delta comment application path (structured schema only)
 # ---------------------------------------------------------------------
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
 @patch(
     "data_lakehouse_ingest.orchestrator.table_processor.apply_comments_from_table_schema",
     autospec=True,
@@ -198,6 +210,7 @@ def test_process_table_applies_delta_comments_for_structured_schema(
     mock_detect_format,
     mock_resolve_schema,
     mock_apply_comments,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -246,7 +259,8 @@ def test_process_table_applies_delta_comments_for_structured_schema(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": {"applied": 1, "skipped": 0, "missing_in_table": []},
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": {"applied": 1, "skipped": 0, "missing_in_table": []},
     }
 
     mock_apply_comments.assert_called_once()
@@ -299,6 +313,11 @@ def test_process_table_applies_delta_comments_for_structured_schema(
 # Delta comment skip path (non-structured schema)
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.apply_comments_from_table_schema",
     autospec=True,
 )
@@ -339,6 +358,7 @@ def test_process_table_does_not_apply_delta_comments_for_non_structured_schema(
     mock_detect_format,
     mock_resolve_schema,
     mock_apply_comments,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -381,7 +401,8 @@ def test_process_table_does_not_apply_delta_comments_for_non_structured_schema(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": None,
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": None,
     }
     mock_apply_comments.assert_not_called()
 
@@ -522,6 +543,11 @@ def test_process_table_data_load_failure(
 # logger.context_filter branch
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
     autospec=True,
     return_value=SimpleNamespace(
@@ -557,6 +583,7 @@ def test_process_table_sets_logger_table_context_when_context_filter_present(
     mock_load_data,
     mock_detect_format,
     mock_resolve_schema,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -603,7 +630,8 @@ def test_process_table_sets_logger_table_context_when_context_filter_present(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": None,
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": None,
     }
     mock_logger.context_filter.set_table.assert_called_once_with("test_table")
 
@@ -731,6 +759,11 @@ def test_process_table_uses_fallback_reader_options_when_loader_has_no_get_defau
 # DataFrame override bypasses bronze loading
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
     autospec=True,
     return_value=SimpleNamespace(
@@ -764,6 +797,7 @@ def test_process_table_dataframe_override_skips_bronze_loading(
     mock_write_to_delta,
     mock_apply_schema_columns,
     mock_resolve_schema,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -811,7 +845,8 @@ def test_process_table_dataframe_override_skips_bronze_loading(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": None,
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": None,
     }
 
     mock_resolve_schema.assert_called_once_with(
@@ -995,7 +1030,12 @@ def test_process_table_dataframe_override_applies_delta_comments_when_available(
     assert result.input_source == InputSource.DATAFRAME
     assert result.bronze_path is None
     assert result.format is None
-    assert result.comments_report == {"applied": 1, "skipped": 0, "missing_in_table": []}
+    assert result.table_comment_report["status"] == "skipped"
+    assert result.column_comments_report == {
+        "applied": 1,
+        "skipped": 0,
+        "missing_in_table": [],
+    }
 
     mock_resolve_schema.assert_called_once_with(
         spark=mock_spark,
@@ -1039,6 +1079,11 @@ def test_process_table_dataframe_override_applies_delta_comments_when_available(
 # Dropped columns reported in result
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "skipped", "reason": "no table comment"},
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
     autospec=True,
     return_value=SimpleNamespace(
@@ -1074,6 +1119,7 @@ def test_process_table_reports_dropped_columns(
     mock_load_data,
     mock_detect_format,
     mock_resolve_schema,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -1116,7 +1162,8 @@ def test_process_table_reports_dropped_columns(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "comments_report": None,
+        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "column_comments_report": None,
     }
 
     mock_resolve_schema.assert_called_once_with(
@@ -1155,3 +1202,259 @@ def test_process_table_reports_dropped_columns(
     assert kwargs["partition_by"] is None
     assert kwargs["mode"] == "overwrite"
     assert kwargs["logger"] == mock_logger
+
+
+# ---------------------------------------------------------------------
+# Delta table level comment
+# ---------------------------------------------------------------------
+
+
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "success", "applied": True},
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
+    autospec=True,
+    return_value=SimpleNamespace(
+        schema_defs="CREATE TABLE ...",
+        schema_source=SchemaSource.SCHEMA_SQL,
+        comment_metadata=None,
+    ),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.detect_format",
+    autospec=True,
+    return_value="csv",
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.load_table_data",
+    autospec=True,
+    return_value=(MagicMock(), 100),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_schema_columns",
+    autospec=True,
+    side_effect=lambda *args, **kwargs: (kwargs["df"], {"dropped_columns": []}),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.write_to_delta",
+    autospec=True,
+    return_value=95,
+)
+def test_process_table_applies_table_level_string_comment(
+    mock_write_to_delta,
+    mock_apply_schema,
+    mock_load_data,
+    mock_detect_format,
+    mock_resolve_schema,
+    mock_apply_table_comment,
+    mock_spark,
+    mock_logger,
+    mock_loader,
+):
+    ctx = {
+        "tenant": "tenant_alpha",
+        "namespace": "tenant_alpha__dataset",
+        "namespace_base_path": "s3a://silver/",
+    }
+
+    table = {
+        "name": "test_table",
+        "format": "csv",
+        "mode": "overwrite",
+        "comment": "Test table comment",
+    }
+
+    result = process_table(
+        spark=mock_spark,
+        logger=mock_logger,
+        loader=mock_loader,
+        ctx=ctx,
+        table=table,
+        run_started_at_iso="2025-10-31T12:00:00Z",
+    )
+
+    assert result.status == ProcessStatus.SUCCESS
+    assert result.table_comment_report == {"status": "success", "applied": True}
+    assert result.column_comments_report is None
+
+    mock_apply_table_comment.assert_called_once_with(
+        spark=mock_spark,
+        full_table_name="tenant_alpha__dataset.test_table",
+        table_comment="Test table comment",
+        logger=mock_logger,
+        require_existing_table=True,
+    )
+
+
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "success", "applied": True},
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
+    autospec=True,
+    return_value=SimpleNamespace(
+        schema_defs="CREATE TABLE ...",
+        schema_source=SchemaSource.SCHEMA_SQL,
+        comment_metadata=None,
+    ),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.detect_format",
+    autospec=True,
+    return_value="csv",
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.load_table_data",
+    autospec=True,
+    return_value=(MagicMock(), 100),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_schema_columns",
+    autospec=True,
+    side_effect=lambda *args, **kwargs: (kwargs["df"], {"dropped_columns": []}),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.write_to_delta",
+    autospec=True,
+    return_value=95,
+)
+def test_process_table_applies_table_level_dict_comment(
+    mock_write_to_delta,
+    mock_apply_schema,
+    mock_load_data,
+    mock_detect_format,
+    mock_resolve_schema,
+    mock_apply_table_comment,
+    mock_spark,
+    mock_logger,
+    mock_loader,
+):
+    ctx = {
+        "tenant": "tenant_alpha",
+        "namespace": "tenant_alpha__dataset",
+        "namespace_base_path": "s3a://silver/",
+    }
+
+    table_comment = {
+        "description": "Test table comment",
+        "owner": "arkinlab",
+    }
+
+    table = {
+        "name": "test_table",
+        "format": "csv",
+        "mode": "overwrite",
+        "comment": table_comment,
+    }
+
+    result = process_table(
+        spark=mock_spark,
+        logger=mock_logger,
+        loader=mock_loader,
+        ctx=ctx,
+        table=table,
+        run_started_at_iso="2025-10-31T12:00:00Z",
+    )
+
+    assert result.status == ProcessStatus.SUCCESS
+    assert result.table_comment_report == {"status": "success", "applied": True}
+    assert result.column_comments_report is None
+
+    mock_apply_table_comment.assert_called_once_with(
+        spark=mock_spark,
+        full_table_name="tenant_alpha__dataset.test_table",
+        table_comment=table_comment,
+        logger=mock_logger,
+        require_existing_table=True,
+    )
+
+
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_comments_from_table_schema",
+    autospec=True,
+    return_value={"applied": 1, "skipped": 0, "missing_in_table": []},
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+    return_value={"status": "success", "applied": True},
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.resolve_schema",
+    autospec=True,
+    return_value=SimpleNamespace(
+        schema_defs=[{"column": "gene_id", "type": "string"}],
+        schema_source=SchemaSource.SCHEMA_STRUCTURED,
+        comment_metadata=[{"column": "gene_id", "type": "string", "comment": "Gene identifier"}],
+    ),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.detect_format",
+    autospec=True,
+    return_value="csv",
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.load_table_data",
+    autospec=True,
+    return_value=(MagicMock(), 100),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_schema_columns",
+    autospec=True,
+    side_effect=lambda *args, **kwargs: (kwargs["df"], {"dropped_columns": []}),
+)
+@patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.write_to_delta",
+    autospec=True,
+    return_value=95,
+)
+def test_process_table_applies_table_and_column_comments(
+    mock_write_to_delta,
+    mock_apply_schema,
+    mock_load_data,
+    mock_detect_format,
+    mock_resolve_schema,
+    mock_apply_table_comment,
+    mock_apply_column_comments,
+    mock_spark,
+    mock_logger,
+    mock_loader,
+):
+    ctx = {
+        "tenant": "tenant_alpha",
+        "namespace": "tenant_alpha__dataset",
+        "namespace_base_path": "s3a://silver/",
+    }
+
+    table = {
+        "name": "test_table",
+        "format": "csv",
+        "mode": "overwrite",
+        "comment": {"description": "table comment"},
+        "schema": [{"column": "gene_id", "type": "string", "comment": "Gene identifier"}],
+    }
+
+    result = process_table(
+        spark=mock_spark,
+        logger=mock_logger,
+        loader=mock_loader,
+        ctx=ctx,
+        table=table,
+        run_started_at_iso="2025-10-31T12:00:00Z",
+    )
+
+    assert result.status == ProcessStatus.SUCCESS
+    assert result.table_comment_report == {"status": "success", "applied": True}
+    assert result.column_comments_report == {
+        "applied": 1,
+        "skipped": 0,
+        "missing_in_table": [],
+    }
+
+    mock_apply_table_comment.assert_called_once()
+    mock_apply_column_comments.assert_called_once()

--- a/tests/orchestrator/test_table_processor.py
+++ b/tests/orchestrator/test_table_processor.py
@@ -124,10 +124,11 @@ def test_process_table_success(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": None,
     }
 
+    mock_apply_table_comment.assert_not_called()
     mock_detect_format.assert_called_once_with("s3a://bronze/test_table/", "csv")
     mock_resolve_schema.assert_called_once_with(
         spark=mock_spark,
@@ -259,7 +260,7 @@ def test_process_table_applies_delta_comments_for_structured_schema(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": {"applied": 1, "skipped": 0, "missing_in_table": []},
     }
 
@@ -401,9 +402,10 @@ def test_process_table_does_not_apply_delta_comments_for_non_structured_schema(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": None,
     }
+
     mock_apply_comments.assert_not_called()
 
     mock_resolve_schema.assert_called_once_with(
@@ -630,9 +632,11 @@ def test_process_table_sets_logger_table_context_when_context_filter_present(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": None,
     }
+
+    mock_apply_table_comment.assert_not_called()
     mock_logger.context_filter.set_table.assert_called_once_with("test_table")
 
     mock_resolve_schema.assert_called_once_with(
@@ -845,9 +849,11 @@ def test_process_table_dataframe_override_skips_bronze_loading(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": None,
     }
+
+    mock_apply_table_comment.assert_not_called()
 
     mock_resolve_schema.assert_called_once_with(
         spark=mock_spark,
@@ -974,6 +980,10 @@ def test_process_table_dataframe_override_sets_format_from_table_or_default(
 # DataFrame override applies Delta comments
 # ---------------------------------------------------------------------
 @patch(
+    "data_lakehouse_ingest.orchestrator.table_processor.apply_table_comment",
+    autospec=True,
+)
+@patch(
     "data_lakehouse_ingest.orchestrator.table_processor.apply_comments_from_table_schema",
     autospec=True,
     return_value={"applied": 1, "skipped": 0, "missing_in_table": []},
@@ -1003,6 +1013,7 @@ def test_process_table_dataframe_override_applies_delta_comments_when_available(
     mock_apply_schema_columns,
     mock_resolve_schema,
     mock_apply_comments,
+    mock_apply_table_comment,
     mock_spark,
     mock_logger,
     mock_loader,
@@ -1030,12 +1041,14 @@ def test_process_table_dataframe_override_applies_delta_comments_when_available(
     assert result.input_source == InputSource.DATAFRAME
     assert result.bronze_path is None
     assert result.format is None
-    assert result.table_comment_report["status"] == "skipped"
+    assert result.table_comment_report is None
     assert result.column_comments_report == {
         "applied": 1,
         "skipped": 0,
         "missing_in_table": [],
     }
+
+    mock_apply_table_comment.assert_not_called()
 
     mock_resolve_schema.assert_called_once_with(
         spark=mock_spark,
@@ -1162,7 +1175,7 @@ def test_process_table_reports_dropped_columns(
         "partitions_written": None,
         "quarantine_path": "s3a://silver//quarantine/2025-10-31T12-00-00Z/",
         "status": ProcessStatus.SUCCESS,
-        "table_comment_report": {"status": "skipped", "reason": "no table comment"},
+        "table_comment_report": None,
         "column_comments_report": None,
     }
 


### PR DESCRIPTION
This PR introduces support for table-level comments in the ingestion pipeline, extending the existing column-level comment functionality. The enhancement ensures that metadata defined in structured schemas can be applied not only at the column level but also at the table level during ingestion.

**Key Changes**
Table-level comment support
- Extended the ingestion flow in `process_table()` to support applying table-level metadata alongside column comments.
- Table-level comments support both string and JSON-style dict metadata.
- Added/updated tests in `test_table_processor.py`