### PR TITLE
Add table-level comment support to delta_comments with fallback and full test coverage

### DIFF
--- a/src/data_lakehouse_ingest/utils/delta_comments.py
+++ b/src/data_lakehouse_ingest/utils/delta_comments.py
@@ -109,14 +109,12 @@ def _try_set_table_comment(
         False otherwise.
     """
     c_sql = _escape_sql_string(comment)
-
     try:
         spark.sql(f'COMMENT ON TABLE {full_table_name} IS "{c_sql}"')
         return True
     except Exception:
         logger.warning(
             f"COMMENT ON TABLE failed for {full_table_name}; trying TBLPROPERTIES fallback",
-            exc_info=True,
         )
 
     try:

--- a/src/data_lakehouse_ingest/utils/delta_comments.py
+++ b/src/data_lakehouse_ingest/utils/delta_comments.py
@@ -1,12 +1,11 @@
 """
-Delta table column comment utilities.
+Delta table and column comment utilities.
 
-Provides helpers to apply column-level comments to existing Spark/Delta
-tables using a structured list-of-maps schema definition. The module
-supports both plain string comments and JSON-style dict comments,
-safely escapes comment strings, skips missing or empty comments gracefully,
-and returns a structured report suitable for logging, auditing, and
-ingestion metadata.
+Provides helpers to apply table-level and column-level comments to existing
+Spark/Delta tables using structured metadata. The module supports both plain
+string comments and JSON-style dict comments, safely escapes comment strings,
+skips missing or empty comments gracefully, and returns structured reports
+suitable for logging, auditing, and ingestion metadata.
 """
 
 import logging
@@ -82,6 +81,49 @@ def _try_alter_column_comment(
         return True
     except Exception:
         logger.exception(f"Failed to set comment for {full_table_name}.{col}")
+        return False
+
+
+def _try_set_table_comment(
+    spark: SparkSession,
+    full_table_name: str,
+    comment: str,
+    logger: logging.Logger,
+) -> bool:
+    """
+    Attempt to set a table-level comment using Spark SQL.
+
+    This function first tries `COMMENT ON TABLE ... IS ...`. If that fails,
+    it falls back to `ALTER TABLE ... SET TBLPROPERTIES ("comment" = ...)`
+    for compatibility with environments where direct table comment syntax
+    is unsupported.
+
+    Args:
+        spark: Active SparkSession.
+        full_table_name: Fully qualified table name.
+        comment: Comment text to apply.
+        logger: Logger used for warning and error messages.
+
+    Returns:
+        True if the table comment was successfully applied,
+        False otherwise.
+    """
+    c_sql = _escape_sql_string(comment)
+
+    try:
+        spark.sql(f'COMMENT ON TABLE {full_table_name} IS "{c_sql}"')
+        return True
+    except Exception:
+        logger.warning(
+            f"COMMENT ON TABLE failed for {full_table_name}; trying TBLPROPERTIES fallback",
+            exc_info=True,
+        )
+
+    try:
+        spark.sql(f'ALTER TABLE {full_table_name} SET TBLPROPERTIES ("comment" = "{c_sql}")')
+        return True
+    except Exception:
+        logger.exception(f"Failed to set table comment for {full_table_name}")
         return False
 
 
@@ -197,4 +239,38 @@ def apply_comments_from_table_schema(
         "skipped": skipped,
         "failed": failed,
         "details": details,
+    }
+
+
+def apply_table_comment(
+    spark: SparkSession,
+    full_table_name: str,
+    table_comment: str | dict[str, Any] | None,
+    logger: logging.Logger | None = None,
+    *,
+    require_existing_table: bool = True,
+) -> dict[str, Any]:
+    logger = logger or logging.getLogger(__name__)
+
+    if require_existing_table and not spark.catalog.tableExists(full_table_name):
+        msg = f"Table does not exist: {full_table_name}"
+        logger.error(msg)
+        return {"table": full_table_name, "status": "failed", "error": msg}
+
+    if isinstance(table_comment, dict):
+        table_comment = json.dumps(table_comment, ensure_ascii=False)
+
+    if not isinstance(table_comment, str) or not table_comment.strip():
+        return {
+            "table": full_table_name,
+            "status": "skipped",
+            "reason": "no table comment",
+        }
+
+    ok = _try_set_table_comment(spark, full_table_name, table_comment, logger)
+
+    return {
+        "table": full_table_name,
+        "status": "success" if ok else "failed",
+        "applied": bool(ok),
     }

--- a/tests/utils/test_delta_comments.py
+++ b/tests/utils/test_delta_comments.py
@@ -5,7 +5,9 @@ import pytest
 from data_lakehouse_ingest.utils.delta_comments import (
     _escape_sql_string,
     _try_alter_column_comment,
+    _try_set_table_comment,
     apply_comments_from_table_schema,
+    apply_table_comment,
 )
 
 
@@ -207,3 +209,145 @@ def test_apply_comments_skips_non_string_non_dict_comment():
     assert report["failed"] == 0
     assert report["details"][0]["status"] == "skipped"
     assert report["details"][0]["reason"] == "no comment"
+
+
+def test_try_set_table_comment_uses_comment_on_table_syntax():
+    """Applies a table-level comment using COMMENT ON TABLE syntax when supported."""
+    spark = FakeSpark()
+    logger = logging.getLogger("test")
+
+    ok = _try_set_table_comment(spark, "db.tbl", "Table level comment", logger)
+
+    assert ok is True
+    assert len(spark.sql_calls) == 1
+    assert 'COMMENT ON TABLE db.tbl IS "Table level comment"' in spark.sql_calls[0]
+
+
+def test_try_set_table_comment_falls_back_to_tblproperties_when_comment_on_table_fails(caplog):
+    """Falls back to ALTER TABLE ... SET TBLPROPERTIES when COMMENT ON TABLE fails."""
+    spark = FakeSpark(sql_side_effects=[Exception("syntax not supported"), []])
+    logger = logging.getLogger("test")
+
+    with caplog.at_level(logging.WARNING):
+        ok = _try_set_table_comment(spark, "db.tbl", "Table level comment", logger)
+
+    assert ok is True
+    assert len(spark.sql_calls) == 2
+    assert 'COMMENT ON TABLE db.tbl IS "Table level comment"' in spark.sql_calls[0]
+    assert (
+        'ALTER TABLE db.tbl SET TBLPROPERTIES ("comment" = "Table level comment")'
+        in spark.sql_calls[1]
+    )
+    assert "COMMENT ON TABLE failed for db.tbl; trying TBLPROPERTIES fallback" in caplog.text
+
+
+def test_try_set_table_comment_returns_false_when_both_attempts_fail(caplog):
+    """Returns False and logs an error when both table comment SQL strategies fail."""
+    spark = FakeSpark(sql_side_effects=[Exception("first fail"), Exception("second fail")])
+    logger = logging.getLogger("test")
+
+    with caplog.at_level(logging.ERROR):
+        ok = _try_set_table_comment(spark, "db.tbl", "Table level comment", logger)
+
+    assert ok is False
+    assert len(spark.sql_calls) == 2
+    assert "Failed to set table comment for db.tbl" in caplog.text
+
+
+def test_apply_table_comment_returns_failed_if_table_missing_when_required():
+    """Returns a failed report when the target table does not exist."""
+    spark = FakeSpark(table_exists=False)
+
+    report = apply_table_comment(
+        spark,
+        "db.tbl",
+        "Table level comment",
+        logger=logging.getLogger("test"),
+        require_existing_table=True,
+    )
+
+    assert report["table"] == "db.tbl"
+    assert report["status"] == "failed"
+    assert "Table does not exist" in report["error"]
+
+
+def test_apply_table_comment_skips_when_comment_is_missing():
+    """Skips table comment application when no table comment is provided."""
+    spark = FakeSpark()
+
+    report = apply_table_comment(
+        spark,
+        "db.tbl",
+        None,
+        logger=logging.getLogger("test"),
+    )
+
+    assert report == {
+        "table": "db.tbl",
+        "status": "skipped",
+        "reason": "no table comment",
+    }
+    assert spark.sql_calls == []
+
+
+def test_apply_table_comment_applies_string_comment():
+    """Applies a plain string table-level comment successfully."""
+    spark = FakeSpark()
+
+    report = apply_table_comment(
+        spark,
+        "db.tbl",
+        "Reference table for genomes",
+        logger=logging.getLogger("test"),
+    )
+
+    assert report == {
+        "table": "db.tbl",
+        "status": "success",
+        "applied": True,
+    }
+    assert len(spark.sql_calls) == 1
+    assert 'COMMENT ON TABLE db.tbl IS "Reference table for genomes"' in spark.sql_calls[0]
+
+
+def test_apply_table_comment_serializes_dict_comment_and_preserves_unicode():
+    """Serializes dict-based table comments to JSON and preserves Unicode characters."""
+    spark = FakeSpark()
+
+    report = apply_table_comment(
+        spark,
+        "db.tbl",
+        {"description": "Café naïve β-cell 漢字", "owner": "arkinlab"},
+        logger=logging.getLogger("test"),
+    )
+
+    assert report == {
+        "table": "db.tbl",
+        "status": "success",
+        "applied": True,
+    }
+
+    sql_text = spark.sql_calls[0]
+    assert 'COMMENT ON TABLE db.tbl IS "' in sql_text
+    assert "Café naïve β-cell 漢字" in sql_text
+    assert '\\"description\\": \\"Café naïve β-cell 漢字\\"' in sql_text
+    assert "\\u" not in sql_text
+
+
+def test_apply_table_comment_skips_non_string_non_dict_comment():
+    """Skips invalid table comments that are neither strings nor dicts."""
+    spark = FakeSpark()
+
+    report = apply_table_comment(
+        spark,
+        "db.tbl",
+        123,
+        logger=logging.getLogger("test"),
+    )
+
+    assert report == {
+        "table": "db.tbl",
+        "status": "skipped",
+        "reason": "no table comment",
+    }
+    assert spark.sql_calls == []


### PR DESCRIPTION
This PR extends the existing comment utilities to support table-level comments in addition to the already supported column-level comments.

The implementation ensures compatibility across different Spark environments by introducing a fallback strategy and maintains consistency with existing structured metadata handling.

**Key Changes**
Table-Level Comment Support
Introduced apply_table_comment() for applying comments at the table level
Supports:
- Plain string comments
- JSON-style dictionary comments (serialized to JSON)