### PR TITLE
Enable ingest telemetry uploader finalization

### DIFF
--- a/src/data_lakehouse_ingest/logger.py
+++ b/src/data_lakehouse_ingest/logger.py
@@ -640,25 +640,22 @@ def finalize_logger(logger: logging.Logger) -> None:
         return
 
     try:
-        # Temporarily disable telemetry uploads while
-        # telemetry-uploader integration is being finalized.
-        pass
-        #
-        # log_file_path = Path(logger.log_file_path)
+        # Compress and upload the completed telemetry log through the telemetry uploader service.
+        log_file_path = Path(logger.log_file_path)
 
-        # compressed_file_path = compress_log_file(log_file_path)
+        compressed_file_path = compress_log_file(log_file_path)
 
-        # object_key = build_ingest_telemetry_key(
-        #     compressed_file_path=compressed_file_path,
-        #     user=logger.context_filter.user,
-        #     pipeline_name=logger.context_filter.pipeline_name,
-        # )
+        object_key = build_ingest_telemetry_key(
+            compressed_file_path=compressed_file_path,
+            user=logger.context_filter.user,
+            pipeline_name=logger.context_filter.pipeline_name,
+        )
 
-        # upload_log_file_to_telemetry_uploader(
-        #     logger=logger,
-        #     compressed_file_path=compressed_file_path,
-        #     object_key=object_key,
-        # )
+        upload_log_file_to_telemetry_uploader(
+            logger=logger,
+            compressed_file_path=compressed_file_path,
+            object_key=object_key,
+        )
 
     except Exception:
         logger.exception("Failed during ingest telemetry finalization")


### PR DESCRIPTION
This PR enables the final telemetry upload step at the end of an ingest run.

Previously, `finalize_logger()` compressed the generated JSONL log and uploaded it through the telemetry uploader service, but this logic was temporarily disabled while the telemetry infrastructure was being finalized.

This change re-enables that functionality.

**Changes**
- Enable compression of the generated JSONL telemetry log.
- Build the telemetry object key using the existing partitioning convention.
- Upload the compressed log through the telemetry uploader service during logger finalization.
- 
**Testing**
- Verified that the telemetry log is compressed successfully.
- Verified that `finalize_logger()` invokes the telemetry uploader.
- Tested successfully against the local telemetry uploader service.

**Notes**
This PR assumes the following environment variables are configured by the deployment environment:

- `INGEST_TELEMETRY_ENABLED`
- `INGEST_TELEMETRY_UPLOAD_URL`
- `INGEST_TELEMETRY_PREFIX`
- `TELEMETRY_TOKEN`