### PR TITLE
Merge develop into main for v0.1.2 release

### DIFF
--- a/.github/workflows/build_publish_scan_managed.yml
+++ b/.github/workflows/build_publish_scan_managed.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 jobs:
   build-publish-scan:
-    uses: BERDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
+    uses: KBaseDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
     permissions:
       contents: read
       packages: write

--- a/src/data_lakehouse_ingest/logger.py
+++ b/src/data_lakehouse_ingest/logger.py
@@ -640,25 +640,22 @@ def finalize_logger(logger: logging.Logger) -> None:
         return
 
     try:
-        # Temporarily disable telemetry uploads while
-        # telemetry-uploader integration is being finalized.
-        pass
-        #
-        # log_file_path = Path(logger.log_file_path)
+        # Compress and upload the completed telemetry log through the telemetry uploader service.
+        log_file_path = Path(logger.log_file_path)
 
-        # compressed_file_path = compress_log_file(log_file_path)
+        compressed_file_path = compress_log_file(log_file_path)
 
-        # object_key = build_ingest_telemetry_key(
-        #     compressed_file_path=compressed_file_path,
-        #     user=logger.context_filter.user,
-        #     pipeline_name=logger.context_filter.pipeline_name,
-        # )
+        object_key = build_ingest_telemetry_key(
+            compressed_file_path=compressed_file_path,
+            user=logger.context_filter.user,
+            pipeline_name=logger.context_filter.pipeline_name,
+        )
 
-        # upload_log_file_to_telemetry_uploader(
-        #     logger=logger,
-        #     compressed_file_path=compressed_file_path,
-        #     object_key=object_key,
-        # )
+        upload_log_file_to_telemetry_uploader(
+            logger=logger,
+            compressed_file_path=compressed_file_path,
+            object_key=object_key,
+        )
 
     except Exception:
         logger.exception("Failed during ingest telemetry finalization")


### PR DESCRIPTION
This PR merges the latest changes from develop into main in preparation for tagging and releasing v0.1.2.

Recent PR merges into develop, including:
- Merge pull request #77 from kbase/feature/enable-telemetry-uploader
- Merge pull request #76 from kbase/chore/ghcr-org-rename

After merge:

A v0.1.2 tag will be created from main
Downstream Docker builds will be updated to use @v0.1.2