### PR TITLE
Update berdl-notebook-utils dependency to KBaseDataLakehouse repository

### DIFF
--- a/.github/workflows/build_publish_scan_managed.yml
+++ b/.github/workflows/build_publish_scan_managed.yml
@@ -13,5 +13,4 @@ jobs:
     permissions:
       contents: read
       packages: write
-    secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
+

--- a/.github/workflows/build_publish_scan_managed.yml
+++ b/.github/workflows/build_publish_scan_managed.yml
@@ -13,3 +13,5 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7.1.2
 
+      - name: Configure GitHub token for private dependencies
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/KBaseDataLakehouse/".insteadOf "https://github.com/KBaseDataLakehouse/"
+
       - name: Install dependencies
         run: uv sync
 
@@ -43,6 +47,10 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7.1.2
+
+      - name: Configure GitHub token for private dependencies
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/KBaseDataLakehouse/".insteadOf "https://github.com/KBaseDataLakehouse/"
 
       - name: Install dependencies
         run: uv sync
@@ -71,6 +79,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Configure GitHub token for private dependencies
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/KBaseDataLakehouse/".insteadOf "https://github.com/KBaseDataLakehouse/"
 
       - name: Install dependencies
         run: uv sync --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,4 @@ select = ["F", "E", "W"] # minimal: pyflakes + pycodestyle
 ignore = ["E501"]        # ignore line length, handled by line-length above
 
 [tool.uv.sources]
-berdl-notebook-utils = { git = "https://github.com/BERDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }
+berdl-notebook-utils = { git = "https://github.com/KBaseDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 [[package]]
 name = "berdl-notebook-utils"
 version = "0.0.1"
-source = { git = "https://github.com/BERDataLakehouse/spark_notebook.git?subdirectory=notebook_utils#9da77ba179c671b7a5e0d97ef8340c9d73911928" }
+source = { git = "https://github.com/KBaseDataLakehouse/spark_notebook.git?subdirectory=notebook_utils#d46f98a6f6f53c4dbfeb34e67e3b8b21d7d073b0" }
 dependencies = [
     { name = "attrs" },
     { name = "cacheout" },
@@ -625,7 +625,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "berdl-notebook-utils", git = "https://github.com/BERDataLakehouse/spark_notebook.git?subdirectory=notebook_utils" },
+    { name = "berdl-notebook-utils", git = "https://github.com/KBaseDataLakehouse/spark_notebook.git?subdirectory=notebook_utils" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "linkml", specifier = ">=1.9.4" },
     { name = "linkml-runtime", specifier = ">=1.9.5" },
@@ -1807,7 +1807,7 @@ wheels = [
 [[package]]
 name = "minio-manager-service-client"
 version = "0.0.1"
-source = { git = "https://github.com/BERDataLakehouse/minio_manager_service_client.git?rev=v0.0.22#20fa3233d041a284bbd6b3cd0efd59d0c60adad9" }
+source = { git = "https://github.com/BERDataLakehouse/minio_manager_service_client.git?rev=v0.0.23#1a1ab502f6c7f86e38672cce571fc5b4ea7ed8b9" }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1807,7 +1807,7 @@ wheels = [
 [[package]]
 name = "minio-manager-service-client"
 version = "0.0.1"
-source = { git = "https://github.com/BERDataLakehouse/minio_manager_service_client.git?rev=v0.0.23#1a1ab502f6c7f86e38672cce571fc5b4ea7ed8b9" }
+source = { git = "https://github.com/KBaseDataLakehouse/minio_manager_service_client.git?rev=v0.0.23#1a1ab502f6c7f86e38672cce571fc5b4ea7ed8b9" }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -658,7 +658,7 @@ wheels = [
 [[package]]
 name = "datalake-mcp-server-client"
 version = "0.0.1"
-source = { git = "https://github.com/BERDataLakehouse/datalake-mcp-server-client.git?rev=v0.0.10#0b13bbdc0c4e62719a8650d30aed1d1578efe8dc" }
+source = { git = "https://github.com/KBaseDataLakehouse/datalake-mcp-server-client.git?rev=v0.0.10#0b13bbdc0c4e62719a8650d30aed1d1578efe8dc" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },


### PR DESCRIPTION
Updates the `berdl-notebook-utils` Git dependency to use the new `KBaseDataLakehouse/spark_notebook` repository.

**Changes**

- Updated `pyproject.toml` to point `berdl-notebook-utils` to the new GitHub repository.
- Updated `uv.lock` to reflect the new Git source and resolved commit.

**Validation**

- Recreated the virtual environment.
- Ran `uv sync --dev`.
- Verified that `berdl-notebook-utils` installs successfully from the private repository.