### PR TITLE
fix: use KBase auth token for telemetry uploads

### DIFF
--- a/src/data_lakehouse_ingest/logger.py
+++ b/src/data_lakehouse_ingest/logger.py
@@ -570,10 +570,13 @@ def upload_log_file_to_telemetry_uploader(
     Upload a compressed telemetry log file through the telemetry uploader service.
     """
     upload_url = os.getenv("INGEST_TELEMETRY_UPLOAD_URL")
-    telemetry_token = os.getenv("TELEMETRY_TOKEN")
+    kbase_auth_token = os.getenv("KBASE_AUTH_TOKEN")
 
-    if not upload_url:
-        logger.warning("Telemetry upload skipped because INGEST_TELEMETRY_UPLOAD_URL is missing")
+    if not upload_url or not kbase_auth_token:
+        logger.warning(
+            "Telemetry upload skipped because "
+            "INGEST_TELEMETRY_UPLOAD_URL or KBASE_AUTH_TOKEN is missing"
+        )
         return False
 
     try:
@@ -581,7 +584,7 @@ def upload_log_file_to_telemetry_uploader(
             response = requests.post(
                 upload_url,
                 headers={
-                    "X-Telemetry-Token": telemetry_token,
+                    "Authorization": f"Bearer {kbase_auth_token}",
                 },
                 data={
                     "object_key": object_key,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -251,8 +251,9 @@ def test_upload_log_file_to_minio_skips_when_env_missing(tmp_path, caplog, monke
 def test_upload_log_file_to_telemetry_uploader_skips_when_url_missing(
     tmp_path, caplog, monkeypatch
 ):
-    """Verify telemetry uploader upload is skipped when INGEST_TELEMETRY_UPLOAD_URL is missing."""
+    """Verify upload is skipped when INGEST_TELEMETRY_UPLOAD_URL is missing."""
     monkeypatch.delenv("INGEST_TELEMETRY_UPLOAD_URL", raising=False)
+    monkeypatch.setenv("KBASE_AUTH_TOKEN", "test-token")
 
     logger = logging.getLogger("test_uploader_skip")
     caplog.set_level(logging.WARNING)
@@ -264,7 +265,7 @@ def test_upload_log_file_to_telemetry_uploader_skips_when_url_missing(
     )
 
     assert result is False
-    assert "INGEST_TELEMETRY_UPLOAD_URL is missing" in caplog.text
+    assert "INGEST_TELEMETRY_UPLOAD_URL or KBASE_AUTH_TOKEN is missing" in caplog.text
 
 
 def test_finalize_logger_flushes_handlers_when_upload_temporarily_disabled(tmp_path):
@@ -373,7 +374,7 @@ def test_upload_log_file_to_telemetry_uploader_logs_failure(tmp_path, caplog, mo
     compressed_file.write_bytes(b"test")
 
     monkeypatch.setenv("INGEST_TELEMETRY_UPLOAD_URL", "http://telemetry-uploader:8080/upload")
-    monkeypatch.setenv("TELEMETRY_TOKEN", "test-token")
+    monkeypatch.setenv("KBASE_AUTH_TOKEN", "test-token")
 
     def fake_post(*args, **kwargs):
         raise RuntimeError("http failed")
@@ -531,7 +532,7 @@ def test_upload_log_file_to_telemetry_uploader_success(tmp_path, monkeypatch, ca
     compressed_file.write_bytes(b"test")
 
     monkeypatch.setenv("INGEST_TELEMETRY_UPLOAD_URL", "http://telemetry-uploader:8080/upload")
-    monkeypatch.setenv("TELEMETRY_TOKEN", "test-token")
+    monkeypatch.setenv("KBASE_AUTH_TOKEN", "test-token")
 
     class FakeResponse:
         def raise_for_status(self):
@@ -539,7 +540,7 @@ def test_upload_log_file_to_telemetry_uploader_success(tmp_path, monkeypatch, ca
 
     def fake_post(url, headers, data, files, timeout):
         assert url == "http://telemetry-uploader:8080/upload"
-        assert headers["X-Telemetry-Token"] == "test-token"
+        assert headers["Authorization"] == "Bearer test-token"
         assert data["object_key"] == "ingest-job-logs/test.zstd"
         assert timeout == 60
         return FakeResponse()


### PR DESCRIPTION
Replace the shared telemetry token authentication with KBase authentication when uploading ingest telemetry logs.

**Changes**
- Use `KBASE_AUTH_TOKEN` instead of `TELEMETRY_TOKEN`.
- Send the KBase token using the standard `Authorization: Bearer <token>` header.
- Skip telemetry uploads when either:
  - `INGEST_TELEMETRY_UPLOAD_URL` is not configured, or
  - `KBASE_AUTH_TOKEN` is unavailable.
- Remove the custom `X-Telemetry-Token` header from upload requests.

**Motivation**
The telemetry uploader service now authenticates requests using KBase Auth instead of a shared static token. This aligns telemetry uploads with the standard KBase service-to-service authentication model and eliminates the need to expose a shared telemetry token in notebook environments.
