### PR TITLE
Add default telemetry configuration for ingest logging

### DIFF
--- a/src/data_lakehouse_ingest/logger.py
+++ b/src/data_lakehouse_ingest/logger.py
@@ -460,7 +460,7 @@ def upload_log_file_to_minio(
         Upload failures are logged but do not interrupt pipeline
         execution.
     """
-    bucket = os.getenv("INGEST_TELEMETRY_BUCKET", "cdm-ingest-job-logs")
+    bucket = os.getenv("INGEST_TELEMETRY_BUCKET", "cdm-telemetry-logs")
     endpoint_url = os.getenv("S3_ENDPOINT_URL")
     access_key = os.getenv("S3_ACCESS_KEY")
     secret_key = os.getenv("S3_SECRET_KEY")


### PR DESCRIPTION
This PR adds default values for telemetry configuration used by the ingest logger.

**Changes**

- Default `INGEST_TELEMETRY_ENABLED` to `true`
- Default `INGEST_TELEMETRY_PREFIX` to `ingest-job-logs`
- Default `INGEST_TELEMETRY_BUCKET` to `cdm-telemetry-logs`

These defaults allow telemetry uploads to work without requiring every notebook environment to explicitly configure these variables while still allowing deployments to override them if needed.